### PR TITLE
Add clear log functionality

### DIFF
--- a/Sources/Shared/Logging/Logger.swift
+++ b/Sources/Shared/Logging/Logger.swift
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: MIT
-// Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
-
 import Foundation
 import os.log
 
@@ -30,6 +27,23 @@ public class Logger {
 
     func writeLog(to targetFile: String) -> Bool {
         return write_log_to_file(targetFile, self.log) == 0
+    }
+
+    func readLog(from filePath: String) -> String? {
+        guard let log = open_log(filePath) else { return nil }
+        defer { close_log(log) }
+        var logEntries = [String]()
+        var cursor: UInt32 = UINT32_MAX
+        cursor = view_lines_from_cursor(log, cursor, &logEntries) { cStr, _, ctx in
+            if let cStr = cStr, let logEntries = ctx?.bindMemory(to: [String].self, capacity: 1) {
+                logEntries.pointee.append(String(cString: cStr))
+            }
+        }
+        return logEntries.joined(separator: "\n")
+    }
+
+    func clearLog() {
+        memset(log, 0, MemoryLayout<OpaquePointer>.size)
     }
 
     static func configureGlobal(tagged tag: String, withFilePath filePath: String?) {

--- a/Sources/WireGuardApp/UI/iOS/ViewController/LogViewController.swift
+++ b/Sources/WireGuardApp/UI/iOS/ViewController/LogViewController.swift
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: MIT
-// Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
-
 import UIKit
 
 class LogViewController: UIViewController {
@@ -60,7 +57,10 @@ class LogViewController: UIViewController {
 
     override func viewDidLoad() {
         title = tr("logViewTitle")
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(saveTapped(sender:)))
+        navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(saveTapped(sender:))),
+            UIBarButtonItem(barButtonSystemItem: .trash, target: self, action: #selector(clearLogTapped(sender:)))
+        ]
     }
 
     func updateLogEntries() {
@@ -143,5 +143,10 @@ class LogViewController: UIViewController {
                 self.present(activityVC, animated: true)
             }
         }
+    }
+
+    @objc func clearLogTapped(sender: AnyObject) {
+        Logger.global?.clearLog()
+        textView.text = ""
     }
 }


### PR DESCRIPTION
Add methods to read and clear logs in Logger class and update LogViewController to clear logs.

* **Logger.swift**
  - Add `readLog(from filePath: String) -> String?` method to read logs from a file.
  - Add `clearLog()` method to clear the log buffer.

* **LogViewController.swift (iOS)**
  - Add `clearLogTapped(sender: AnyObject)` method to clear the log.
  - Add a button to the navigation bar to clear the log.

## Summary by Sourcery

Add log reading and clearing functionality to the Logger class and LogViewController

New Features:
- Implement method to read logs from a file
- Add ability to clear log buffer

Enhancements:
- Update LogViewController to include a clear log button in the navigation bar

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/JohnDaWalka/wireguard-apple/1)
<!-- Reviewable:end -->
