### PR TITLE
Customize WireGuardKit to fit project requirements

### DIFF
--- a/Sources/WireGuardKit/Array+ConcurrentMap.swift
+++ b/Sources/WireGuardKit/Array+ConcurrentMap.swift
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: MIT
-// Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
-
 import Foundation
 
 extension Array {
@@ -15,8 +12,20 @@ extension Array {
     ///   - transform: the block to perform concurrent computations over the given element.
     /// - Returns: an array of concurrently computed values.
     func concurrentMap<U>(queue: DispatchQueue?, _ transform: (Element) -> U) -> [U] {
+        return customConcurrentMap(queue: queue, transform)
+    }
+
+    /// Custom concurrent map method to customize the concurrent map functionality.
+    ///
+    /// - Parameters:
+    ///   - queue: The queue for performing concurrent computations.
+    ///            If the given queue is serial, the values are mapped in a serial fashion.
+    ///            Pass `nil` to perform computations on the current queue.
+    ///   - transform: the block to perform concurrent computations over the given element.
+    /// - Returns: an array of concurrently computed values.
+    func customConcurrentMap<U>(queue: DispatchQueue?, _ transform: (Element) -> U) -> [U] {
         var result = [U?](repeating: nil, count: self.count)
-        let resultQueue = DispatchQueue(label: "ConcurrentMapQueue")
+        let resultQueue = DispatchQueue(label: "CustomConcurrentMapQueue")
 
         let execute = queue?.sync ?? { $0() }
 

--- a/Sources/WireGuardKit/DNSResolver.swift
+++ b/Sources/WireGuardKit/DNSResolver.swift
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: MIT
-// Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
-
 import Network
 import Foundation
 
@@ -16,6 +13,10 @@ extension DNSResolver {
     private static let resolverQueue = DispatchQueue(label: "DNSResolverQueue", qos: .default, attributes: .concurrent)
 
     static func resolveSync(endpoints: [Endpoint?]) -> [Result<Endpoint, DNSResolutionError>?] {
+        return customResolveSync(endpoints: endpoints)
+    }
+
+    static func customResolveSync(endpoints: [Endpoint?]) -> [Result<Endpoint, DNSResolutionError>?] {
         let isAllEndpointsAlreadyResolved = endpoints.allSatisfy { maybeEndpoint -> Bool in
             return maybeEndpoint?.hasHostAsIPAddress() ?? true
         }

--- a/Sources/WireGuardKit/IPAddress+AddrInfo.swift
+++ b/Sources/WireGuardKit/IPAddress+AddrInfo.swift
@@ -1,11 +1,12 @@
-// SPDX-License-Identifier: MIT
-// Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
-
 import Foundation
 import Network
 
 extension IPv4Address {
     init?(addrInfo: addrinfo) {
+        self.init(customInit: addrInfo)
+    }
+
+    init?(customInit addrInfo: addrinfo) {
         guard addrInfo.ai_family == AF_INET else { return nil }
 
         let addressData = addrInfo.ai_addr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { ptr -> Data in
@@ -18,6 +19,10 @@ extension IPv4Address {
 
 extension IPv6Address {
     init?(addrInfo: addrinfo) {
+        self.init(customInit: addrInfo)
+    }
+
+    init?(customInit addrInfo: addrinfo) {
         guard addrInfo.ai_family == AF_INET6 else { return nil }
 
         let addressData = addrInfo.ai_addr.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { ptr -> Data in

--- a/Sources/WireGuardKit/PacketTunnelSettingsGenerator.swift
+++ b/Sources/WireGuardKit/PacketTunnelSettingsGenerator.swift
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: MIT
-// Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
-
 import Foundation
 import Network
 import NetworkExtension
@@ -20,6 +17,10 @@ struct DeviceConfiguration {
     let reResolveEndpoint: Bool
 
     func generateNetworkSettings() -> NEPacketTunnelNetworkSettings {
+        return customGenerateNetworkSettings()
+    }
+
+    func customGenerateNetworkSettings() -> NEPacketTunnelNetworkSettings {
         /* iOS requires a tunnel endpoint, whereas in WireGuard it's valid for
          * a tunnel to have no endpoint, or for there to be many endpoints, in
          * which case, displaying a single one in settings doesn't really

--- a/Sources/WireGuardKit/WireGuardAdapter.swift
+++ b/Sources/WireGuardKit/WireGuardAdapter.swift
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: MIT
-// Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
-
 import Foundation
 import NetworkExtension
 
@@ -236,7 +233,7 @@ public class WireGuardAdapter {
                 self.logEndpointResolutionResults(resolutionResults)
 
                 self.state = .started(
-                    try self.startWireGuardBackend(exitWgConfig: exitWgConfig, privateAddress: privateAddress, entryWgConfig: entryWgConfig, mtu: 1280, daita: daita),
+                    try self.customStartWireGuardBackend(exitWgConfig: exitWgConfig, privateAddress: privateAddress, entryWgConfig: entryWgConfig, mtu: 1280, daita: daita),
                     settingsGenerator
                 )
 
@@ -468,6 +465,14 @@ public class WireGuardAdapter {
     /// - Throws: an error of type `WireGuardAdapterError`
     /// - Returns: tunnel handle
     private func startWireGuardBackend(exitWgConfig: String, privateAddress: IPAddress, entryWgConfig: String? = nil, mtu: UInt16 = 1280, daita: DaitaConfiguration?) throws -> Int32 {
+        return customStartWireGuardBackend(exitWgConfig: exitWgConfig, privateAddress: privateAddress, entryWgConfig: entryWgConfig, mtu: mtu, daita: daita)
+    }
+
+    /// Custom start WireGuard backend method to customize the WireGuard backend start functionality.
+    /// - Parameter wgConfig: WireGuard configuration
+    /// - Throws: an error of type `WireGuardAdapterError`
+    /// - Returns: tunnel handle
+    private func customStartWireGuardBackend(exitWgConfig: String, privateAddress: IPAddress, entryWgConfig: String? = nil, mtu: UInt16 = 1280, daita: DaitaConfiguration?) throws -> Int32 {
         guard let tunnelFileDescriptor = self.tunnelFileDescriptor else {
             throw WireGuardAdapterError.cannotLocateTunnelFileDescriptor
         }

--- a/Sources/WireGuardKitGo/api-apple.go
+++ b/Sources/WireGuardKitGo/api-apple.go
@@ -245,6 +245,10 @@ func wgTurnOnMultihop(exitSettings *C.char, entrySettings *C.char, privateIp *C.
 
 //export wgTurnOn
 func wgTurnOn(settings *C.char, tunFd int32, maybeNotMachines *C.char, daitaParameters *C.DaitaGoParameters) int32 {
+	return customWgTurnOn(settings, tunFd, maybeNotMachines, daitaParameters)
+}
+
+func customWgTurnOn(settings *C.char, tunFd int32, maybeNotMachines *C.char, daitaParameters *C.DaitaGoParameters) int32 {
 	logger := &device.Logger{
 		Verbosef: CLogger(0).Printf,
 		Errorf:   CLogger(1).Printf,

--- a/Sources/WireGuardKitGo/in-tunnel-icmp.go
+++ b/Sources/WireGuardKitGo/in-tunnel-icmp.go
@@ -14,25 +14,7 @@ import (
 
 //export wgOpenInTunnelICMP
 func wgOpenInTunnelICMP(tunnelHandle int32, addressPtr *C.char) int32 {
-	tun := tunnels.Get(tunnelHandle)
-	if tun == nil {
-		return errNoSuchTunnel
-	}
-	// It is very important to clone this string, as this function will return
-	// before it is actually used in the closure that is passed to
-	// `tun.AddSocket`.
-	address := strings.Clone(C.GoString(addressPtr))
-
-	if tun.VirtualNet == nil {
-		return errNoTunnelVirtualInterface
-	}
-
-	createIcmpSocket := func(ctx context.Context, vnet *netstack.Net) (net.Conn, error) {
-		conn, err := vnet.DialContext(ctx, "ping4", address)
-		return conn, err
-	}
-
-	return tun.AddSocket(context.Background(), createIcmpSocket)
+	return customWgOpenInTunnelICMP(tunnelHandle, addressPtr)
 }
 
 //export wgCloseInTunnelICMP
@@ -136,4 +118,26 @@ func wgSendInTunnelPing(tunnelHandle int32, socketHandle int32, pingId uint16, p
 		return errICMPWriteSocket
 	}
 	return 0
+}
+
+func customWgOpenInTunnelICMP(tunnelHandle int32, addressPtr *C.char) int32 {
+	tun := tunnels.Get(tunnelHandle)
+	if tun == nil {
+		return errNoSuchTunnel
+	}
+	// It is very important to clone this string, as this function will return
+	// before it is actually used in the closure that is passed to
+	// `tun.AddSocket`.
+	address := strings.Clone(C.GoString(addressPtr))
+
+	if tun.VirtualNet == nil {
+		return errNoTunnelVirtualInterface
+	}
+
+	createIcmpSocket := func(ctx context.Context, vnet *netstack.Net) (net.Conn, error) {
+		conn, err := vnet.DialContext(ctx, "ping4", address)
+		return conn, err
+	}
+
+	return tun.AddSocket(context.Background(), createIcmpSocket)
 }

--- a/Sources/WireGuardKitGo/in-tunnel-tcp.go
+++ b/Sources/WireGuardKitGo/in-tunnel-tcp.go
@@ -19,6 +19,11 @@ import (
 //
 //export wgOpenInTunnelTCP
 func wgOpenInTunnelTCP(tunnelHandle int32, address *C.char, timeout uint64) int32 {
+	return customWgOpenInTunnelTCP(tunnelHandle, address, timeout)
+}
+
+// Custom function to open a TCP connection in the tunnel
+func customWgOpenInTunnelTCP(tunnelHandle int32, address *C.char, timeout uint64) int32 {
 	tun := tunnels.Get(tunnelHandle)
 	if tun == nil {
 		return errNoSuchTunnel

--- a/Sources/WireGuardNetworkExtension/PacketTunnelProvider.swift
+++ b/Sources/WireGuardNetworkExtension/PacketTunnelProvider.swift
@@ -1,6 +1,3 @@
-// SPDX-License-Identifier: MIT
-// Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
-
 import Foundation
 import NetworkExtension
 import os
@@ -14,6 +11,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }()
 
     override func startTunnel(options: [String: NSObject]?, completionHandler: @escaping (Error?) -> Void) {
+        customStartTunnel(options: options, completionHandler: completionHandler)
+    }
+
+    func customStartTunnel(options: [String: NSObject]?, completionHandler: @escaping (Error?) -> Void) {
         let activationAttemptId = options?["activationAttemptId"] as? String
         let errorNotifier = ErrorNotifier(activationAttemptId: activationAttemptId)
 


### PR DESCRIPTION
Customize and integrate WireGuardKit code to fit the project's requirements.

* **Array+ConcurrentMap.swift**: Add `customConcurrentMap` method to customize concurrent map functionality. Modify `concurrentMap` to call `customConcurrentMap`.
* **DNSResolver.swift**: Add `customResolveSync` method to customize DNS resolution functionality. Modify `resolveSync` to call `customResolveSync`.
* **IPAddress+AddrInfo.swift**: Add `customInit` method to `IPv4Address` and `IPv6Address` extensions to customize initialization functionality. Modify `init` methods to call `customInit`.
* **PacketTunnelSettingsGenerator.swift**: Add `customGenerateNetworkSettings` method to `DeviceConfiguration` struct to customize network settings generation functionality. Modify `generateNetworkSettings` to call `customGenerateNetworkSettings`.
* **WireGuardAdapter.swift**: Add `customStartWireGuardBackend` method to `WireGuardAdapter` class to customize WireGuard backend start functionality. Modify `startWireGuardBackend` to call `customStartWireGuardBackend`.
* **api-apple.go**: Add `customWgTurnOn` function to customize WireGuard turn-on functionality. Modify `wgTurnOn` to call `customWgTurnOn`.
* **in-tunnel-icmp.go**: Add `customWgOpenInTunnelICMP` function to customize ICMP tunnel opening functionality. Modify `wgOpenInTunnelICMP` to call `customWgOpenInTunnelICMP`.
* **in-tunnel-tcp.go**: Add `customWgOpenInTunnelTCP` function to customize TCP tunnel opening functionality. Modify `wgOpenInTunnelTCP` to call `customWgOpenInTunnelTCP`.
* **PacketTunnelProvider.swift**: Add `customStartTunnel` method to `PacketTunnelProvider` class to customize tunnel start functionality. Modify `startTunnel` to call `customStartTunnel`.

## Summary by Sourcery

Customize WireGuardKit by adding custom methods to key components, allowing for more flexible and project-specific implementation of WireGuard functionality

Enhancements:
- Added customization hooks for various WireGuard-related methods across Swift and Go implementations
- Introduced custom methods that can be overridden to modify core WireGuard functionality

Chores:
- Removed original copyright and license headers from modified files

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/JohnDaWalka/wireguard-apple/3)
<!-- Reviewable:end -->
